### PR TITLE
Add full variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,18 @@ will be missing; install the `compiler-lib` package to get most of the standard
 `raco` commands.
 
 Versions: 6.1 and above
+
+## Building the images
+
+To build the images locally, run
+
+    $ env DOCKER_USERNAME=you ./build.sh
+
+from the command line, replacing `you` with whatever your Docker Hub
+username is.  After building the images, you can test them all with
+
+    $ env DOCKER_USERNAME=you ./test.sh
+
+and you can deploy them to Docker Hub with
+
+    $ env DOCKER_USERNAME=you ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ will be missing; install the `compiler-lib` package to get most of the standard
 
 Versions: 6.1 and above
 
+#### "Full" images
+
+Base: `buildpack-deps`
+
+CMD: `racket`
+
+These images, tagged with `-full` at the end, use the full Racket
+distribution.
+
 ## Building the images
 
 To build the images locally, run

--- a/_common.sh
+++ b/_common.sh
@@ -2,8 +2,10 @@
 
 set -euxfo pipefail;
 
-USERNAME="${DOCKER_USERNAME:-jackfirth}"
+USERNAME="${DOCKER_USERNAME}"
 
 find_images () {
-    docker images --format '{{.Repository}}:{{.Tag}}' | grep "^${USERNAME}/racket:[[:digit:]]" | sort
+    docker images --format '{{.Repository}}:{{.Tag}}' | \
+        grep "^${USERNAME}/racket:[[:digit:]]" | \
+        sort;
 }

--- a/_common.sh
+++ b/_common.sh
@@ -2,6 +2,8 @@
 
 set -euxfo pipefail;
 
+USERNAME="${DOCKER_USERNAME:-jackfirth}"
+
 find_images () {
-    docker images --format '{{.Repository}}:{{.Tag}}' | grep "^jackfirth/racket:[[:digit:]]" | sort
+    docker images --format '{{.Repository}}:{{.Tag}}' | grep "^${USERNAME}/racket:[[:digit:]]" | sort
 }

--- a/_common.sh
+++ b/_common.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euxfo pipefail;
+
+find_images () {
+    docker images --format '{{.Repository}}:{{.Tag}}' | grep "^jackfirth/racket:[[:digit:]]" | sort
+}

--- a/_common.sh
+++ b/_common.sh
@@ -5,6 +5,11 @@ set -euxfo pipefail;
 USERNAME="${DOCKER_USERNAME}"
 
 find_images () {
+    # This image is filtered out by the grep below so we might as well
+    # add it manually rather than come up with some clever regexp.
+    echo "${USERNAME}/racket:latest";
+
+    # Grab all of the racket images whose "tag"s start with a digit.
     docker images --format '{{.Repository}}:{{.Tag}}' | \
         grep "^${USERNAME}/racket:[[:digit:]]" | \
         sort;

--- a/build.sh
+++ b/build.sh
@@ -9,19 +9,7 @@ build () {
   declare -r base_image="${2}";
   declare -r installer_url="${3}";
   declare -r version="${4}";
-  declare -r variant="${5}";
-
-  declare tag="${USERNAME}/racket:${version}"
-  case "${variant}" in
-      "-minimal") ;;
-
-      "") tag="${tag}-full"
-          ;;
-
-      *) echo "error: unexpected variant '${variant}'"
-         exit 1
-         ;;
-  esac
+  declare -r tag="${5}";
 
   docker image build \
       --file "${dockerfile_name}.Dockerfile" \
@@ -40,11 +28,16 @@ installer_url () {
 
 build_6x_7x () {
   declare -r version="${1}";
-  for variant in "" "-minimal"; do
-      installer_path="racket${variant}-${version}-x86_64-linux-natipkg.sh";
-      installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
-      build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${variant}";
-  done
+  declare installer_path;
+  declare installer;
+
+  installer_path="racket-minimal-${version}-x86_64-linux-natipkg.sh";
+  installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
+  build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${USERNAME}/racket:${version}";
+
+  installer_path="racket-${version}-x86_64-linux-natipkg.sh";
+  installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
+  build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${USERNAME}/racket:${version}-full";
 };
 
 build_6x_old () {

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,8 @@ set -euxfo pipefail;
 
 source "_common.sh";
 
+declare -r LATEST_RACKET_VERSION="7.4";
+
 build () {
   declare -r dockerfile_name="${1}";
   declare -r base_image="${2}";
@@ -65,3 +67,5 @@ foreach () {
 foreach build_6x_7x "7.4" "7.3" "7.2" "7.1" "7.0" "6.12" "6.11" "6.10.1" "6.10" "6.9" "6.8" "6.7" "6.6" "6.5";
 foreach build_6x_old "6.4" "6.3" "6.2.1" "6.2" "6.1.1";
 foreach build_6x_old_ospkg "6.1" "6.0.1" "6.0";
+
+docker image tag "${USERNAME}/racket:${LATEST_RACKET_VERSION}" "${USERNAME}/racket:latest";

--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,23 @@ build () {
   declare -r base_image="${2}";
   declare -r installer_url="${3}";
   declare -r version="${4}";
+  declare -r variant="${5}";
+
+  declare tag="jackfirth/racket:${version}"
+  case "${variant}" in
+      "-minimal") ;;
+
+      "") tag="${tag}-full"
+          ;;
+
+      *) echo "error: unexpected variant '${variant}'"
+         exit 1
+         ;;
+  esac
+
   docker image build \
       --file "${dockerfile_name}.Dockerfile" \
-      --tag "jackfirth/racket:${version}" \
+      --tag "${tag}" \
       --build-arg "BASE_IMAGE=${base_image}" \
       --build-arg "RACKET_INSTALLER_URL=${installer_url}" \
       --build-arg "RACKET_VERSION=${version}" \
@@ -24,9 +38,11 @@ installer_url () {
 
 build_6x_7x () {
   declare -r version="${1}";
-  declare -r installer_path="racket-minimal-${version}-x86_64-linux-natipkg.sh";
-  declare -r installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:stable" "${installer}" "${version}";
+  for variant in "" "-minimal"; do
+      installer_path="racket${variant}-${version}-x86_64-linux-natipkg.sh";
+      installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
+      build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${variant}";
+  done
 };
 
 build_6x_old () {

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 
 set -euxfo pipefail;
 
+source "_common.sh";
+
 build () {
   declare -r dockerfile_name="${1}";
   declare -r base_image="${2}";
@@ -9,7 +11,7 @@ build () {
   declare -r version="${4}";
   declare -r variant="${5}";
 
-  declare tag="jackfirth/racket:${version}"
+  declare tag="${USERNAME}/racket:${version}"
   case "${variant}" in
       "-minimal") ;;
 

--- a/build.sh
+++ b/build.sh
@@ -33,13 +33,13 @@ build_6x_7x () {
   declare installer_path;
   declare installer;
 
-  installer_path="racket-minimal-${version}-x86_64-linux-natipkg.sh";
-  installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
+  declare -r installer_path="racket-minimal-${version}-x86_64-linux-natipkg.sh";
+  declare -r installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
   build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${USERNAME}/racket:${version}";
 
-  installer_path="racket-${version}-x86_64-linux-natipkg.sh";
-  installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${USERNAME}/racket:${version}-full";
+  declare -r full_installer_path="racket-${version}-x86_64-linux-natipkg.sh";
+  declare -r full_installer=$(installer_url "${version}" "${full_installer_path}") || exit "${?}";
+  build "racket" "buildpack-deps:stable" "${full_installer}" "${version}" "${USERNAME}/racket:${version}-full";
 };
 
 build_6x_old () {

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,42 +2,17 @@
 
 set -euxfo pipefail;
 
+source "_common.sh";
+
 declare -r LATEST_RACKET_VERSION="7.4";
 
 docker image tag "jackfirth/racket:${LATEST_RACKET_VERSION}" "jackfirth/racket:latest";
 
 push () {
-  declare -r version="${1}";
-  docker image push "jackfirth/racket:${version}";
+  declare -r image="${1}";
+  docker image push "${image}";
 };
 
-foreach () {
-  declare -r command="${1}";
-  declare -r args="${@:2}";
-  for _arg in ${args}; do
-    "${command}" "${_arg}";
-  done;
-};
-
-foreach push \
-    "latest" \
-    "7.4" \
-    "7.3" \
-    "7.2" \
-    "7.1" \
-    "7.0" \
-    "6.12" \
-    "6.11" \
-    "6.10.1" \
-    "6.10" \
-    "6.9" \
-    "6.8" \
-    "6.7" \
-    "6.6" \
-    "6.5" \
-    "6.4" \
-    "6.3" \
-    "6.2.1" \
-    "6.2" \
-    "6.1.1" \
-    "6.1";
+for image in $(find_images); do
+    push "${image}";
+done

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,15 +4,11 @@ set -euxfo pipefail;
 
 source "_common.sh";
 
-declare -r LATEST_RACKET_VERSION="7.4";
-
-docker image tag "${USERNAME}/racket:${LATEST_RACKET_VERSION}" "${USERNAME}/racket:latest";
-
 push () {
   declare -r image="${1}";
   docker image push "${image}";
 };
 
 for image in $(find_images); do
-    push "${image}";
+  push "${image}";
 done

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@ source "_common.sh";
 
 declare -r LATEST_RACKET_VERSION="7.4";
 
-docker image tag "jackfirth/racket:${LATEST_RACKET_VERSION}" "jackfirth/racket:latest";
+docker image tag "${USERNAME}/racket:${LATEST_RACKET_VERSION}" "${USERNAME}/racket:latest";
 
 push () {
   declare -r image="${1}";

--- a/test.sh
+++ b/test.sh
@@ -6,15 +6,8 @@ source "_common.sh";
 
 test-image () {
   declare -r image="${1}";
-
-  if echo "${image}" | grep "\-full" -q; then
-      test_package="deta-lib";  # rackunit-lib is already installed in the -full variant
-  else
-      test_package="rackunit-lib";
-  fi
-
   docker container run -it "${image}" racket -e "(+ 1 2 3)";
-  docker container run -it "${image}" raco pkg install --auto "${test_package}";
+  docker container run -it "${image}" raco pkg install --auto nevermore;
 };
 
 for image in $(find_images); do

--- a/test.sh
+++ b/test.sh
@@ -2,39 +2,21 @@
 
 set -euxfo pipefail;
 
+source "_common.sh";
+
 test-image () {
-  declare -r version="${1}";
-  declare -r image="jackfirth/racket:${version}";
+  declare -r image="${1}";
+
+  if echo "${image}" | grep "\-full" -q; then
+      test_package="deta-lib";  # rackunit-lib is already installed in the -full variant
+  else
+      test_package="rackunit-lib";
+  fi
+
   docker container run -it "${image}" racket -e "(+ 1 2 3)";
-  docker container run -it "${image}" raco pkg install --auto rackunit-lib;
+  docker container run -it "${image}" raco pkg install --auto "${test_package}";
 };
 
-foreach () {
-  declare -r command="${1}";
-  declare -r args="${@:2}";
-  for _arg in ${args}; do
-    "${command}" "${_arg}";
-  done;
-};
-
-foreach test-image \
-    "7.4" \
-    "7.3" \
-    "7.2" \
-    "7.1" \
-    "7.0" \
-    "6.12" \
-    "6.11" \
-    "6.10.1" \
-    "6.10" \
-    "6.9" \
-    "6.8" \
-    "6.7" \
-    "6.6" \
-    "6.5" \
-    "6.4" \
-    "6.3" \
-    "6.2.1" \
-    "6.2" \
-    "6.1.1" \
-    "6.1";
+for image in $(find_images); do
+    test-image "${image}";
+done

--- a/test.sh
+++ b/test.sh
@@ -11,5 +11,5 @@ test-image () {
 };
 
 for image in $(find_images); do
-    test-image "${image}";
+  test-image "${image}";
 done


### PR DESCRIPTION
As promised, here's a PR to add `-full` variants to the images.  I stopped at the `6x_7x` series, but we could also apply this to some of the older versions.

I also went ahead and changed the `deploy.sh` and `test.sh` scripts to dynamically discover the images. If you don't like that, I'd be happy to change it back.