### PR TITLE
Configure racket/racket as primary repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
   build:
     docker:
       - image: circleci/buildpack-deps:stable
-    environment:
-      DOCKER_USERNAME: jackfirth
     steps:
       - checkout
       - setup_remote_docker
@@ -14,8 +12,6 @@ jobs:
   build-and-deploy:
     docker:
       - image: circleci/buildpack-deps:stable
-    environment:
-      DOCKER_USERNAME: jackfirth
     steps:
       - checkout
       - setup_remote_docker

--- a/_common.sh
+++ b/_common.sh
@@ -2,23 +2,32 @@
 
 set -euxfo pipefail;
 
-USERNAME="${DOCKER_USERNAME}"
+DOCKER_REPOSITORY="racket/racket";
+
+# We used to push images to the jackfirth/racket DockerHub repo instead
+# of racket/racket. For backwards compatibility, we still push the images
+# to that repo in addition to the primary racket/racket repo.
+SECONDARY_DOCKER_REPOSITORY="jackfirth/racket";
 
 find_images () {
+    declare -r repository="${1}";
+
     # This image is filtered out by the grep below so we might as well
     # add it manually rather than come up with some clever regexp.
-    echo "${USERNAME}/racket:latest";
+    echo "${repository}:latest";
 
     # Grab all of the racket images whose "tag"s start with a digit.
     docker images --format '{{.Repository}}:{{.Tag}}' | \
-        grep "^${USERNAME}/racket:[[:digit:]]" | \
+        grep "^${repository}:[[:digit:]]" | \
         sort;
 }
 
 find_testable_images () {
+    declare -r repository="${1}";
+
     # Version 6.0 is ignored during test runs because its openssl
     # bindings are broken.
     #
     # xref: https://github.com/jackfirth/racket-docker/issues/35
-    find_images | grep --invert-match "racket:6.0"
+    find_images "${repository}" | grep --invert-match "${repository}:6.0"
 }

--- a/build.sh
+++ b/build.sh
@@ -9,15 +9,19 @@ build () {
   declare -r base_image="${2}";
   declare -r installer_url="${3}";
   declare -r version="${4}";
-  declare -r tag="${5}";
+  declare -r image_name="${5}";
+  declare -r tag="${DOCKER_REPOSITORY}:${image_name}";
+  declare -r secondary_tag="${SECONDARY_DOCKER_REPOSITORY}:${image_name}";
 
   docker image build \
       --file "${dockerfile_name}.Dockerfile" \
-      --tag "${tag}" \
+      --tag "${DOCKER_REPOSITORY}:${image_name}" \
       --build-arg "BASE_IMAGE=${base_image}" \
       --build-arg "RACKET_INSTALLER_URL=${installer_url}" \
       --build-arg "RACKET_VERSION=${version}" \
       .;
+
+  docker image tag "${tag}" "${secondary_tag}";
 };
 
 installer_url () {
@@ -31,19 +35,19 @@ build_7x () {
 
   declare -r installer_path="racket-minimal-${version}-x86_64-linux-natipkg.sh";
   declare -r installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${USERNAME}/racket:${version}";
+  build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${version}";
 
   declare -r cs_installer_path="racket-minimal-${version}-x86_64-linux-natipkg-cs.sh";
   declare -r cs_installer=$(installer_url "${version}" "${cs_installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:stable" "${cs_installer}" "${version}" "${USERNAME}/racket:${version}-cs";
+  build "racket" "buildpack-deps:stable" "${cs_installer}" "${version}" "${version}-cs";
 
   declare -r full_installer_path="racket-${version}-x86_64-linux-natipkg.sh";
   declare -r full_installer=$(installer_url "${version}" "${full_installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:stable" "${full_installer}" "${version}" "${USERNAME}/racket:${version}-full";
+  build "racket" "buildpack-deps:stable" "${full_installer}" "${version}" "${version}-full";
 
   declare -r full_cs_installer_path="racket-${version}-x86_64-linux-natipkg-cs.sh";
   declare -r full_cs_installer=$(installer_url "${version}" "${full_cs_installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:stable" "${full_cs_installer}" "${version}" "${USERNAME}/racket:${version}-cs-full";
+  build "racket" "buildpack-deps:stable" "${full_cs_installer}" "${version}" "${version}-cs-full";
 };
 
 build_6x_7x_old () {
@@ -51,11 +55,11 @@ build_6x_7x_old () {
 
   declare -r installer_path="racket-minimal-${version}-x86_64-linux-natipkg.sh";
   declare -r installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${USERNAME}/racket:${version}";
+  build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${version}";
 
   declare -r full_installer_path="racket-${version}-x86_64-linux-natipkg.sh";
   declare -r full_installer=$(installer_url "${version}" "${full_installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:stable" "${full_installer}" "${version}" "${USERNAME}/racket:${version}-full";
+  build "racket" "buildpack-deps:stable" "${full_installer}" "${version}" "${version}-full";
 };
 
 build_6x_old () {
@@ -63,11 +67,11 @@ build_6x_old () {
 
   declare -r installer_path="racket-minimal-${version}-x86_64-linux-natipkg-debian-squeeze.sh";
   declare -r installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:wheezy" "${installer}" "${version}" "${USERNAME}/racket:${version}";
+  build "racket" "buildpack-deps:wheezy" "${installer}" "${version}" "${version}";
 
   declare -r full_installer_path="racket-${version}-x86_64-linux-natipkg-debian-squeeze.sh";
   declare -r full_installer=$(installer_url "${version}" "${full_installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:wheezy" "${full_installer}" "${version}" "${USERNAME}/racket:${version}-full";
+  build "racket" "buildpack-deps:wheezy" "${full_installer}" "${version}" "${version}-full";
 };
 
 build_6x_old_ospkg () {
@@ -75,11 +79,11 @@ build_6x_old_ospkg () {
 
   declare -r installer_path="racket-minimal-${version}-x86_64-linux-debian-squeeze.sh";
   declare -r installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:wheezy" "${installer}" "${version}" "${USERNAME}/racket:${version}";
+  build "racket" "buildpack-deps:wheezy" "${installer}" "${version}" "${version}";
 
   declare -r full_installer_path="racket-${version}-x86_64-linux-debian-squeeze.sh";
   declare -r full_installer=$(installer_url "${version}" "${full_installer_path}") || exit "${?}";
-  build "racket" "buildpack-deps:wheezy" "${full_installer}" "${version}" "${USERNAME}/racket:${version}-full";
+  build "racket" "buildpack-deps:wheezy" "${full_installer}" "${version}" "${version}-full";
 };
 
 foreach () {
@@ -97,4 +101,10 @@ foreach build_6x_7x_old "7.3" "7.2" "7.1" "7.0" "6.12" "6.11" "6.10.1" "6.10" "6
 foreach build_6x_old "6.4" "6.3" "6.2.1" "6.2" "6.1.1";
 foreach build_6x_old_ospkg "6.1" "6.0.1" "6.0";
 
-docker image tag "${USERNAME}/racket:${LATEST_RACKET_VERSION}" "${USERNAME}/racket:latest";
+tag_latest () {
+  declare -r repository="${1}";
+  docker image tag "${repository}:${LATEST_RACKET_VERSION}" "${repository}:latest";
+};
+
+tag_latest "${DOCKER_REPOSITORY}";
+tag_latest "${SECONDARY_DOCKER_REPOSITORY}";

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,10 @@ push () {
   docker image push "${image}";
 };
 
-for image in $(find_images); do
+for image in $(find_images "${DOCKER_REPOSITORY}"); do
+  push "${image}";
+done
+
+for image in $(find_images "${SECONDARY_DOCKER_REPOSITORY}"); do
   push "${image}";
 done

--- a/test.sh
+++ b/test.sh
@@ -7,9 +7,17 @@ source "_common.sh";
 test-image () {
   declare -r image="${1}";
   docker container run -it "${image}" racket -e "(+ 1 2 3)";
+
+  # The "nevermore" package is an empty package that never changes which we
+  # created specifically for this test. This lets us test that package
+  # installation works and the default package catalogs are properly configured.
   docker container run -it "${image}" raco pkg install --auto nevermore;
 };
 
-for image in $(find_testable_images); do
+for image in $(find_testable_images "${DOCKER_REPOSITORY}"); do
+  test-image "${image}";
+done
+
+for image in $(find_testable_images "${SECONDARY_DOCKER_REPOSITORY}"); do
   test-image "${image}";
 done


### PR DESCRIPTION
Closes #43. This commit changes the primary image repository to `racket/racket`, with `jackfirth/racket` preserved as a secondary repository for backwards compatibility. All images are pushed to both repositories, but the intent is that users of the `jackfirth/racket` repository switch to the `racket/racket` repository. Both tags of the same images are tested in order to ensure they were tagged correctly and really do refer to the same image.

Also, this commit removes the `DOCKER_USERNAME` environment variable and replaces it with constants in `_common.sh`, since there's no particular reason that info needed to be passed through the CircleCI config. Note that the `DOCKER_USERNAME` variable, used to name the images, was distinct from the `DOCKER_USER_NAME` variable, which was used to login to Docker Hub. The latter remains and is configured within CircleCI directly alongside an email and password.