### PR TITLE
build: add 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # racket-docker [![Circle CI](https://circleci.com/gh/jackfirth/racket-docker.svg?style=svg)](https://circleci.com/gh/jackfirth/racket-docker)
-Docker images for various Racket versions available on DockerHub as [`racket/racket:<version>`](https://hub.docker.com/r/racket/racket/). For example, to run a Racket 7.9 REPL:
+Docker images for various Racket versions available on DockerHub as [`racket/racket:<version>`](https://hub.docker.com/r/racket/racket/). For example, to run a Racket 8.0 REPL:
 
 ```
-$ docker run -it racket/racket:7.9
+$ docker run -it racket/racket:8.0
 ```
 
 #### Normal images
@@ -15,7 +15,7 @@ These images use the `minimal-install` of Racket to avoid pulling in things like
 DrRacket or Scribble. This also means many `raco` commands such as `raco make`
 will be missing; install the `compiler-lib` package to get most of the standard
 `raco` commands. Alternatively, use the "full" images instead such as
-`racket/racket:7.9-full`.
+`racket/racket:8.0-full`.
 
 Versions: 6.1 and above. Racket CS images are available for 7.4 and above.
 
@@ -27,16 +27,28 @@ CMD: `racket`
 
 These images, tagged with `-full` at the end, use the full Racket distribution.
 
-#### Racket-on-ChezScheme images
+#### Racket on Chez (CS) images
 
 Base: `buildpack-deps`
 
 CMD: `racket`
 
-These images, tagged with `-cs` and `-cs-full` at the end, use the
-`minimal-install` and the full install of Racket-on-Chez,
-respectively. For example, `racket/racket:7.9-cs-full` is the non-minimal Racket
-CS 7.9 variant.
+As of Racket 8.0, CS is the default variant of Racket so the regular
+images (such as `racket/racket:8.0` or `racket/racket:8.0-full`) are
+now based on CS.
+
+Racket CS images for versions prior to 8.0 are tagged as `-cs` and
+`-cs-full`, respectively.  For example, `racket/racket:7.9-cs-full` is
+the full distribution of the CS variant of Racket 7.9.
+
+#### Racket before Chez (BC) images
+
+As of the 8.0 release, Racket BC images are tagged with `-bc` and
+`-bc-full`.  For example, `racket/racket:8.0-bc-full` is the full
+distribution of the BC variant of Racket 8.0, whereas
+`racket/racket:7.9-full` is the full distribution of the BC variant of
+Racket 7.9 (before CS was made the default).
+
 
 ## Local development
 

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,26 @@ installer_url () {
   echo "http://mirror.racket-lang.org/installers/${version}/${installer_path}";
 };
 
+build_8x () {
+  declare -r version="${1}";
+
+  declare -r installer_path="racket-minimal-${version}-x86_64-linux-natipkg.sh";
+  declare -r installer=$(installer_url "${version}" "${installer_path}") || exit "${?}";
+  build "racket" "buildpack-deps:stable" "${installer}" "${version}" "${version}";
+
+  declare -r bc_installer_path="racket-minimal-${version}-x86_64-linux-bc.sh";
+  declare -r bc_installer=$(installer_url "${version}" "${bc_installer_path}") || exit "${?}";
+  build "racket" "buildpack-deps:stable" "${bc_installer}" "${version}" "${version}-bc";
+
+  declare -r full_installer_path="racket-${version}-x86_64-linux-natipkg.sh";
+  declare -r full_installer=$(installer_url "${version}" "${full_installer_path}") || exit "${?}";
+  build "racket" "buildpack-deps:stable" "${full_installer}" "${version}" "${version}-full";
+
+  declare -r full_bc_installer_path="racket-${version}-x86_64-linux-bc.sh";
+  declare -r full_bc_installer=$(installer_url "${version}" "${full_bc_installer_path}") || exit "${?}";
+  build "racket" "buildpack-deps:stable" "${full_bc_installer}" "${version}" "${version}-bc-full";
+};
+
 build_7x () {
   declare -r version="${1}";
 
@@ -94,8 +114,9 @@ foreach () {
   done;
 };
 
-declare -r LATEST_RACKET_VERSION="7.9";
+declare -r LATEST_RACKET_VERSION="8.0";
 
+foreach build_8x "8.0";
 foreach build_7x "7.4" "7.5" "7.6" "7.7" "7.8" "7.9";
 foreach build_6x_7x_old "7.3" "7.2" "7.1" "7.0" "6.12" "6.11" "6.10.1" "6.10" "6.9" "6.8" "6.7" "6.6" "6.5";
 foreach build_6x_old "6.4" "6.3" "6.2.1" "6.2" "6.1.1";


### PR DESCRIPTION
A couple irregular things about this change:

* CS is now the default (yay!), which means the tag structure has to change (well, it doesn't _have_ to, but it's probably going to be less confusing down the line if we rip the bandaid off now)
* There are no official natipkg builds for Racket BC 8.0 so I used the regular installers.

Happy to make any changes you like if you think there's a better approach to be taken here.