### PR TITLE
Build for Racket 8.4 (Feb 2022)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,7 +122,7 @@ foreach () {
   done;
 };
 
-declare -r LATEST_RACKET_VERSION="8.3";
+declare -r LATEST_RACKET_VERSION="8.4";
 
 tag_latest () {
   declare -r repository="${1}";
@@ -130,7 +130,7 @@ tag_latest () {
 };
 
 build_all_8x () {
-  foreach build_8x "8.0" "8.1" "8.2" "8.3";
+  foreach build_8x "8.0" "8.1" "8.2" "8.3" "8.4";
   tag_latest "${DOCKER_REPOSITORY}";
   tag_latest "${SECONDARY_DOCKER_REPOSITORY}";
 }


### PR DESCRIPTION
This PR:

- adds Racket 8.4 from February 2022 to the list of targets to be built and
- replaces Racket 8.3 by Racket 8.4 as latest Racket version.

I did not update the README even if it used Racket 8.3 as an example because the examples seemed still valid. I can update it as well if you prefer.