### PR TITLE
ci: fix deploy-snapshot schedule

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,7 +1,7 @@
 name: Deploy Snapshots
 on:
   schedule:
-    - cron: "* 0/6 * * *"
+    - cron: "0 0/6 * * *"
 jobs:
   build:
     name: "Build, test & deploy snapshot images"


### PR DESCRIPTION
I noticed more snapshot builds were running than expected and it was
due to the cron schedule being wrong.  This also explains the somewhat
frequent failures since we were probably hammering the snapshot server
every 6 hours.